### PR TITLE
Fix webhook file handling and downloads

### DIFF
--- a/backend/src/utils/receivedFiles.js
+++ b/backend/src/utils/receivedFiles.js
@@ -1,0 +1,13 @@
+export const fileStore = new Map()
+
+export function storeFile(jobId, data, fileName, mimeType) {
+  fileStore.set(jobId, { data, mimeType, fileName })
+}
+
+export function getFile(jobId) {
+  return fileStore.get(jobId)
+}
+
+export function deleteFile(jobId) {
+  fileStore.delete(jobId)
+}

--- a/lib/receivedFiles.ts
+++ b/lib/receivedFiles.ts
@@ -1,0 +1,19 @@
+export interface StoredFile {
+  data: Buffer
+  mimeType: string
+  fileName: string
+}
+
+const fileStore = new Map<string, StoredFile>()
+
+export function storeFile(jobId: string, data: Buffer, fileName: string, mimeType: string) {
+  fileStore.set(jobId, { data, mimeType, fileName })
+}
+
+export function getFile(jobId: string): StoredFile | undefined {
+  return fileStore.get(jobId)
+}
+
+export function deleteFile(jobId: string) {
+  fileStore.delete(jobId)
+}


### PR DESCRIPTION
## Summary
- store incoming webhook binary files in-memory
- allow webhook-response-handler to wait for binary and save it
- serve stored files in download-binary API route
- mirror same logic in Fastify backend

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402fb6f82c8330b89d7278a142c297